### PR TITLE
Fix URL bug with accidental double slash

### DIFF
--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -23,7 +23,7 @@ export default function CommunityMap({community, categories}) {
   const debouncedSearchPhrase = useDebounce(searchPhrase, 500);
 
   const {error} = useSWR(
-    `${URLS.LOCATIONS}/?community__path_slug=${community.path_slug}&category=${
+    `${URLS.LOCATIONS}?community__path_slug=${community.path_slug}&category=${
       selectedCategory?.pk ?? ""
     }&search=${debouncedSearchPhrase ?? ""}`,
     async (url) => {


### PR DESCRIPTION
The newly added trailing slash was doubling the slash for this particular URL, leading to a failed request.