### PR TITLE
Change label and swap directions on Google Maps link

### DIFF
--- a/components/poi-drawer.tsx
+++ b/components/poi-drawer.tsx
@@ -218,12 +218,12 @@ export default function PoiDrawer({community, categories}: PoiDrawerProps) {
               <div className="flex items-center font-semibold text-gray-600">
                 <MapIcon className="flex-none inline h-5 w-5 mr-3 text" />
                 <a
-                    href={`https://www.google.com/maps/dir/${address}`}
+                    href={`https://www.google.com/maps/dir//${address}`}
                     target="_blank"
                     rel="noreferrer"
                     className="px-3 py-1 gap-1 bg-blue-200 rounded-2xl text-xs font-bold uppercase"
                 >
-                  deschide harta
+                  Navigaţie Google
                 </a>
               </div>
           )}


### PR DESCRIPTION
- Changes button label to something more fitting
- Swaps directions to the right order in Google Maps (address is target, not source)
